### PR TITLE
[Backport 1.7] Make TestContainerPids more resilient

### DIFF
--- a/integration/client/container_test.go
+++ b/integration/client/container_test.go
@@ -580,17 +580,43 @@ func TestContainerPids(t *testing.T) {
 	if taskPid < 1 {
 		t.Errorf("invalid task pid %d", taskPid)
 	}
-	processes, err := task.Pids(ctx)
-	switch runtime.GOOS {
-	case "windows":
-		// TODO: This is currently not implemented on windows
-	default:
+
+	tryUntil := time.Now().Add(time.Second)
+	checkPids := func() bool {
+		processes, err := task.Pids(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		// 2 processes, 1 for sh and one for sleep
-		if l := len(processes); l != 2 {
-			t.Errorf("expected 2 process but received %d", l)
+
+		l := len(processes)
+		// The point of this test is to see that we successfully can get all of
+		// the pids running in the container and they match the number expected,
+		// but for Windows this concept is a bit different. Windows containers
+		// essentially go through the usermode boot phase of the operating system,
+		// and have quite a few processes and system services running outside of
+		// the "init" process you specify. Because of this, there's not a great
+		// way to say "there should only be N processes running" like we can ensure
+		// for Linux based off the process we asked to run.
+		//
+		// With all that said, on Windows lets check that we're greater than one
+		// ("init" + system services/procs)
+		if runtime.GOOS == "windows" {
+			if l <= 1 {
+				t.Errorf("expected more than one process but received %d", l)
+			}
+		} else {
+			// 2 processes, 1 for sh and one for sleep
+			if l != 2 {
+				if l == 1 && time.Now().Before(tryUntil) {
+					// The subcommand may not have been started when the
+					// pids are requested. Retrying is a simple way to
+					// handle the race under normal conditions. A better
+					// but more complex solution would be first waiting
+					// for output from the subprocess to be seen.
+					return true
+				}
+				t.Errorf("expected 2 process but received %d", l)
+			}
 		}
 
 		var found bool
@@ -603,7 +629,13 @@ func TestContainerPids(t *testing.T) {
 		if !found {
 			t.Errorf("pid %d must be in %+v", taskPid, processes)
 		}
+		return false
 	}
+
+	for checkPids() {
+		time.Sleep(5 * time.Millisecond)
+	}
+
 	if err := task.Kill(ctx, syscall.SIGKILL); err != nil {
 		select {
 		case s := <-statusC:


### PR DESCRIPTION
ListPids may not pick up the sh subprocess yet when it is first run. To make this test more resilient, retry fetching the processes if only a single pid is found for a short time.


(cherry picked from commit bddeba8250f14f5697520a13cee08ad04b1aa11e)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
