### PR TITLE
core/runtime/v2: fix race on Windows deferredPipeConnection.c in Read

### DIFF
--- a/core/runtime/v2/shim_windows.go
+++ b/core/runtime/v2/shim_windows.go
@@ -42,11 +42,9 @@ type deferredPipeConnection struct {
 }
 
 func (dpc *deferredPipeConnection) Read(p []byte) (n int, err error) {
+	dpc.wg.Wait()
 	if dpc.c == nil {
-		dpc.wg.Wait()
-		if dpc.c == nil {
-			return 0, dpc.conerr
-		}
+		return 0, dpc.conerr
 	}
 	return dpc.c.Read(p)
 }


### PR DESCRIPTION
Read short-circuited on `if dpc.c == nil` before calling `dpc.wg.Wait()` which races with the dialer goroutine spawned in openShimLog. The dialer assigns `dpc.c = c` (and may set `dpc.conerr`) outside any lock; the only synchronization is the WaitGroup, and Read skipped it on the fast path.

`net.Conn` is an interface (two pointer-sized words), so the racy read can also tear: the reader observes a non-nil interface whose dataptr is still nil, the `== nil` check is false, and the subsequent `dpc.c.Read(p)` deferences a half-written value and crashes.

Call `wg.Wait()` unconditionally before touching `dpc.c`. Once the WaitGroup counter has reached zero, Wait() is effectively a single atomic load, so the fast path it was guarding has no measurable cost to give up. Close() already does an unconditional Wait() for the same reason.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
